### PR TITLE
fixing artwork model - "belongs to" class_name attribute 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
@@ -244,6 +246,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -1,6 +1,6 @@
 class Artwork < ApplicationRecord
   validates :artist_name, :title, :theme, :year, :price, :details, presence: true
 
-  belongs_to :owner, class: "User"
+  belongs_to :owner, class_name: "User"
   has_many :offers, dependent: :destroy
 end


### PR DESCRIPTION
Fixing artwork.rb file to have correct belongs_to attribute - update from "class" to "class_name" 

<img width="777" alt="image" src="https://user-images.githubusercontent.com/114599711/201887001-a08d497e-7c74-4f90-915d-fe1827e6bee2.png">


