### PR TITLE
create username and surname with type string

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,7 +8,15 @@
                 required: true,
                 autofocus: true,
                 input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
+ <%= f.input :first_name,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "First Name" }%>
+  <%= f.input :last_name,
+                required: true,
+                autofocus: true,
+                input_html: { autocomplete: "Last Name" }%>
+  <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
                 input_html: { autocomplete: "new-password" } %>

--- a/db/migrate/20221116040419_changed_name_surname_to_string.rb
+++ b/db/migrate/20221116040419_changed_name_surname_to_string.rb
@@ -1,0 +1,4 @@
+class ChangedNameSurnameToString < ActiveRecord::Migration[7.0]
+  def change
+  end
+end

--- a/db/migrate/20221116061746_add_username_lastname_to_users.rb
+++ b/db/migrate/20221116061746_add_username_lastname_to_users.rb
@@ -1,4 +1,4 @@
-class AddNameSurnametoUsers < ActiveRecord::Migration[7.0]
+class AddUsernameLastnameToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column(:users, :first_name, :string, null: false)
     add_column(:users, :last_name, :string, null: false)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_16_052853) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_16_061746) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -45,6 +45,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_16_052853) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name", null: false
+    t.string "last_name", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Currently no user_name and last_name in users model.

I migrated the following changes to schema:
 - t.string "first_name", null: false
 - t.string "last_name", null: false
