### PR TITLE
Added offer seeds and corrected description on artwork seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@
 require 'faker'
 puts "Cleaning up database..."
 
-# Offer.destroy_all
+Offer.destroy_all
 Artwork.destroy_all
 User.destroy_all
 
@@ -36,9 +36,47 @@ id_range = User.last.id - User.first.id
     theme: Faker::Game.genre.gsub("\u0000", ''),
     year: rand(1500..2022),
     price: rand(1..10000000),
-    details: Faker::String.random(length: 3..400).gsub("\u0000", ''),
+    details: Faker::Quote.famous_last_words,
     owner_id: User.first.id + rand(1..id_range)
   )
   end
 
+puts "Populating offers"
+id_range = User.last.id - User.first.id
+artwork_range = Artwork.last.id - Artwork.first.id
+3.times do |count|
+  artWorkID = Artwork.first.id + rand(1..artwork_range)
+  # if !Offer.where(buyer_id: artWorkID).exists?
+  Offer.create!(
+    amount: Artwork.find(artWorkID).price*0.9,
+    artwork_id: artWorkID,
+    buyer_id: User.first.id + rand(1..id_range))
+    # owner_id: User.find(RandomId)                )
+  end
+
 puts "Seeding completed"
+
+
+# create_table "offers", force: :cascade do |t|
+#   t.integer "amount"
+#   t.bigint "artwork_id"
+#   t.bigint "buyer_id"
+#   t.datetime "created_at", null: false
+#   t.datetime "updated_at", null: false
+#   t.index ["artwork_id"], name: "index_offers_on_artwork_id"
+#   t.index ["buyer_id"], name: "index_offers_on_buyer_id"
+# end
+
+# # 10.times do |count|
+# {
+# # create artworks
+# # @artwork = Artwork.new(xxxx)
+# # create user
+# # @user = User.new(xxx)
+# # create offers
+#   @offer = Offer.new(xxx)
+#   @offer.artwork = @artwork
+#   @offer.user = @user
+
+
+# }


### PR DESCRIPTION
- I have added offers seed to the previous user and artwork seeds. The offer creates a record with an actual id from the users and artworks table, and sets a price at 90% of the sale price offered by the seller. 
- I have added the description of the artwork seed to be a quote (instead of the long line of gibberish text from before). 

Examples of Offer:
 #<Offer:0x0000000108c768a8                                        
  id: 15,                                                          
  amount: 842133,                                                  
  artwork_id: 157,                                               
  buyer_id: 695,                                                 
  created_at: Thu, 17 Nov 2022 04:19:12.951277000 UTC +00:00,    
  updated_at: Thu, 17 Nov 2022 04:19:12.951277000 UTC +00:00>,

Example Artwork:
                                                               
#<Artwork:0x00000001083cfe70                                       
 id: 157,                                                          
 artist_name: "Ansel Adams",                                       
 title: "Ricochet",                                                
 theme: "First-person shooter",                                    
 year: 1981,                                                       
 price: 935704,                                                    
 details: "It's stopped.",                                         
 owner_id: 696,                                                    
 created_at: Thu, 17 Nov 2022 04:19:12.920306000 UTC +00:00,       
 updated_at: Thu, 17 Nov 2022 04:19:12.920306000 UTC +00:00>       
irb(main):004:0> 
                   
Example of User:

=> #<User id: 695, email: "nathanael.mraz@example.net", created_at: "2022-11-17 04:19:12.160809000 +0000", updated_at: "2022-11-17 04:19:12.160809000 +0000", first_name: "Ricky", last_name: "Morar">
irb(main):005:0> 


