### PR TITLE
Added header to buy page when user is not signed in

### DIFF
--- a/app/views/artworks/index.html.erb
+++ b/app/views/artworks/index.html.erb
@@ -18,6 +18,10 @@
         <div class="col-auto">
           <%= link_to "Offers I've made", offers_path, {class: 'btn btn-outline-dark'} %>
         </div>
+      <% else %>
+        <div class= "col-auto me-auto">
+          <h1>Collect art and design online</h1>
+        </div>
     <% end %>
   </div>
 

--- a/app/views/devise/shared/_carousel2.html.erb
+++ b/app/views/devise/shared/_carousel2.html.erb
@@ -1,4 +1,3 @@
-
 <div id="carouselExampleDark" class="carousel carousel-dark slide" data-interval="false">
   <div class="carousel-indicators">
     <button class="indicator" type="button" data-bs-target="#carouselExampleDark" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>


### PR DESCRIPTION
# Description

Fixes # (issue)
Added default header to buy page (artworks index)  when user is not signed in

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [ ] local server
- [ ] heroku
