### PR TITLE
fixed carousel styling - indicators working

### DIFF
--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -8,6 +8,12 @@
   object-fit: cover;
 }
 
+.carousel-text {
+  margin-left: 60px;
+  align-items: center;
+  width: 80%;
+}
+
 .carousel-text h1 {
   align-items: center;
   width: 60%;
@@ -35,21 +41,22 @@
   // background-color: rgba(70, 70, 70, 0.25);
   margin-top: 220px;
   transform: translate(0, -10px);
+}
 
 .carousel-control-prev-icon {
   position: absolute;
-  bottom: -20px;
+  bottom: -25px;
   left: 20px;
 }
 
 .carousel-control-next-icon {
   position: absolute;
-  bottom: -20px;
+  bottom: -25px;
   right: 20px;
 }
 
 .carousel-indicators {
-  bottom: -20px;
+  bottom: -40px;
 
   .indicator {
     opacity: 0.3;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -1,7 +1,7 @@
 .navbar-lewagon {
   justify-content: space-between;
   background: white;
-  border: 1px black solid;
+  border: 1px rgb(231, 231, 231) solid;
 
   .flex {
     display: inline-flex;

--- a/app/views/devise/shared/_carousel2.html.erb
+++ b/app/views/devise/shared/_carousel2.html.erb
@@ -26,7 +26,7 @@
       <div class="overlay-image">
         <div class="row align-items-center">
             <div class="col-md">
-              <img class="d-block w-100" src="https://images.unsplash.com/flagged/photo-1572392640988-ba48d1a74457?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=764&q=80" alt="Second slide">
+              <img class="d-block w-100" src="https://images.unsplash.com/photo-1668613964763-90d0bd6559f7?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxlZGl0b3JpYWwtZmVlZHw5fHx8ZW58MHx8fHw%3D&auto=format&fit=crop&w=800&q=60" alt="Second slide">
             </div>
             <div class="col-md py-2 first">
               <div class="carousel-text">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,7 @@
 <%= render "devise/shared/navbar" %>
 <%= render "devise/shared/carousel2" %>
 
+<br>
 
 <div class="container">
   <h3 style="font-family: font-family: ll-unica77, 'Helvetica Neue', Helvetica, Arial, sans-serif;">Latest Artworks</h3>
@@ -8,7 +9,7 @@
     <% @artworks.last(3).each do |artwork|%>
     <div class="card-index" style="margin: 30px">
      <%= link_to artwork_path(artwork), :style=>'text-decoration: none;' do %>
-     <%= cl_image_tag artwork.photo.key, height: 200, width: 200, crop: :fill, class: "card-img-top" %>
+     <%= cl_image_tag artwork.photo.key, height: 400, width: 200, crop: :fill, class: "card-img-top" %>
         <div class="card-body-index">
           <div class="title">
             <p class="p-index">Artist: <%= artwork.artist_name %></p>


### PR DESCRIPTION
# Description
Fixed indicators styling on the carousel - can click indicators now to go to different slides.

<img width="1440" alt="Screenshot 2022-11-21 at 9 12 08 AM" src="https://user-images.githubusercontent.com/108777684/202938041-234d8908-7692-46e3-9d33-bd94c02a47b7.png">

tbd: could have more slides if needed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] rails console
- [ ] local server
- [ ] heroku
