### PR TITLE
Removed seemore from offers index

### DIFF
--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -15,7 +15,6 @@
     <tr>
       <th scope="row"><%= index + 1 %></th>
       <td>$<%= offer.amount %></td>
-      <td><%= link_to "See more", offer_path(offer)%></td>
       <td><%= offer.created_at %></td>
       <td><%= offer.status %></td>
       <% if offer.status == "pending" %>

--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -49,7 +49,6 @@
       <th scope="row"><%= index + 1 %></th>
       <td><%= link_to offer.artwork.title, offer.artwork, class: "site-link" %></td>
       <td>$<%= offer.amount %></td>
-      <td><%= link_to "See more", offer_path(offer)%></td>
       <td><%= offer.created_at %></td>
       <td><%= offer.status %></td>
             <% if offer.status == "pending" %>


### PR DESCRIPTION
# Description

Currently have a "see more" option on offers that is no longer required.


Fixes # (issue)

I have removed "see more"  from the Offers page.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] rails console
- [x] local server
- [ ] heroku
